### PR TITLE
Add basic support for newsfeed links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ Companion website to
 The "CLI" is not really a CLI yet but it *will* fetch missing for crates that don't specify
 their repo in `ecosystem.json`.
 
-If you know of a GUI crate, you can either submit an issue or make a PR!
+If you know of a GUI crate or want to update the news feed, you can either submit an issue or
+make a PR!
 
-Current format for `ecosystem.json` is
+To add a **crate**, add it to `ecosystem.json`, Current format for `ecosystem.json` is
 
 ```js
 {
@@ -31,6 +32,22 @@ Current format for `ecosystem.json` is
 Once you add a crate to the JSON file, you can simply do `cargo run` from the `cli` directory
 and the CLI will generate the website (which is outputted into the `docs` directory).
 
+The process is the same for adding to the **newsfeed**, except you edit `newsfeed.json`. The
+format for each entry is
+
+```rust
+{
+    kind: "Link",
+    title: String,
+    author: String,
+    link: String,
+}
+```
+
+**Please add to the top of the file.** Only links are supported at the moment, but if you have
+a suggestion for another format, or would like to write a blog post exclusively for this site,
+open an issue!
+
 `ecosystem_tags.json` lists descriptions for tags. There should not be any unused tags listed
 in there and not all tags need to have a description, so not all tags need to be in that file.
 
@@ -42,7 +59,7 @@ compile and requires about half a gigabyte of disk space.
 Major undertakings remaining:
  - Crate search based on the tags and an optional query
  - Decide how we want to record approaches
- - Build the page for the newsfeed and start gathering posts
+ - Refactor to support the dedicated newsfeed page (for when we have more than 3 posts)
  - A reviewer or reviewers for blog posts and approaches written exclusively for our repo
  - Add commands to the CLI so people never have to touch the JSON files
  - Pull missing data from github and possibly other sites (bitbucket/gitlab?) if they have

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -9,6 +9,10 @@ extern crate reqwest;
 #[macro_use]
 extern crate tera;
 
+mod newsfeed;
+
+use newsfeed::NewsfeedEntry;
+
 use serde::de::DeserializeOwned;
 
 use std::path::Path;
@@ -24,6 +28,7 @@ struct AreWeGuiYet {
     ///
     /// Some tags may have descriptions.
     tags: HashMap<String, Option<String>>,
+    newsfeed: Vec<NewsfeedEntry>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -152,6 +157,8 @@ fn main() {
         .expect("Failed to parse ecosystem.json");
     let mut tags: HashMap<String, Option<String>> = parse_json_file("../ecosystem_tags.json")
         .expect("Failed to parse ecosystem_tags.json");
+    let newsfeed: Vec<NewsfeedEntry> = parse_json_file("../newsfeed.json")
+        .expect("Failed to parse newsfeed.json");
     let mut cache: Cache = parse_json_file("../cache.json")
         .unwrap_or_else(|_| Default::default());
 
@@ -184,6 +191,7 @@ fn main() {
     let awgy = AreWeGuiYet {
         crates,
         tags,
+        newsfeed,
     };
 
     // update the cache

--- a/cli/src/newsfeed.rs
+++ b/cli/src/newsfeed.rs
@@ -1,0 +1,9 @@
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(tag = "kind")]
+pub enum NewsfeedEntry {
+    Link {
+        title: String,
+        author: String,
+        link: String,
+    }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -52,10 +52,22 @@
             </section>
             <section id="newsfeed" class="centered-content">
                 <h2><a href="#newsfeed">Stay in the loop.</a></h2>
-                <p>We plan to maintain a PR/Issue based newsfeed. If you're working on or
-                    writing about GUIs in Rust, please contribute! Each news entry can either
-                    be a post contributed to the Repo or a link back to your blog, Reddit
-                    thread, etc.</p>
+                <p>If you're working on or writing about GUIs in Rust, please contribute! Each
+                    news entry can either be a post contributed to the Repo or a link back to
+                    your blog, Reddit thread, etc. See
+                    <a href="https://github.com/areweguiyet/areweguiyet/blob/master/README.md">
+                    README</a> for details.</p>
+                <div class="newsfeed-posts">
+                    
+                        <div>
+                            <h3>Entity-Component-System architecture for UI in Rust by Raph Levien</h3>
+                            
+    <a href="https:&#x2F;&#x2F;raphlinus.github.io&#x2F;personal&#x2F;2018&#x2F;05&#x2F;08&#x2F;ecs-ui.html">https:&#x2F;&#x2F;raphlinus.github.io&#x2F;personal&#x2F;2018&#x2F;05&#x2F;08&#x2F;ecs-ui.html</a>
+
+                        </div>
+                    
+                </div>
+                
             </section>
             <section id="ecosystem" class="ecosystem-navigator">
                 <div class="centered-content">

--- a/docs/main.css
+++ b/docs/main.css
@@ -119,6 +119,18 @@ p {
     color: #9f703d;
 }
 
+.newsfeed-posts {
+    padding: 0px 20px;
+}
+
+.newsfeed-posts > div {
+    margin-bottom: 20px
+}
+
+.newsfeed-posts > div > h3 {
+    margin-bottom: 10px;
+}
+
 .ecosystem-navigator, .about-container {
     background: #222;
     color: #eee;

--- a/docs/newsfeed/index.html
+++ b/docs/newsfeed/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Newsfeed - Are we GUI yet?</title>
+    </head>
+    <body>
+        <h1>TODO: Generate news feed page!</h1>
+        <p>This requires some refactoring, but nobody will notice until we have more than 3 posts anyways!</p>
+    </body>
+</html>

--- a/newsfeed.json
+++ b/newsfeed.json
@@ -1,0 +1,8 @@
+[
+    {
+        "kind": "Link",
+        "title": "Entity-Component-System architecture for UI in Rust",
+        "author": "Raph Levien",
+        "link": "https://raphlinus.github.io/personal/2018/05/08/ecs-ui.html"
+    }
+]

--- a/site/base.tera.html
+++ b/site/base.tera.html
@@ -52,10 +52,22 @@
             </section>
             <section id="newsfeed" class="centered-content">
                 <h2><a href="#newsfeed">Stay in the loop.</a></h2>
-                <p>We plan to maintain a PR/Issue based newsfeed. If you're working on or
-                    writing about GUIs in Rust, please contribute! Each news entry can either
-                    be a post contributed to the Repo or a link back to your blog, Reddit
-                    thread, etc.</p>
+                <p>If you're working on or writing about GUIs in Rust, please contribute! Each
+                    news entry can either be a post contributed to the Repo or a link back to
+                    your blog, Reddit thread, etc. See
+                    <a href="https://github.com/areweguiyet/areweguiyet/blob/master/README.md">
+                    README</a> for details.</p>
+                <div class="newsfeed-posts">
+                    {% for post in newsfeed | slice(start=0, end=3) %}
+                        <div>
+                            <h3>{{post.title}} by {{post.author}}</h3>
+                            {{macros::link(label=post.link, href=post.link)}}
+                        </div>
+                    {% endfor %}
+                </div>
+                {% if newsfeed | length > 3 %}
+                    <a href="./newsfeed">See more posts</a>
+                {% endif %}
             </section>
             <section id="ecosystem" class="ecosystem-navigator">
                 <div class="centered-content">


### PR DESCRIPTION
I used Raph Levien's post

https://raphlinus.github.io/personal/2018/05/08/ecs-ui.html

to test basic functionality. The dedicated newsfeed page still needs to be written, which will require breaking up the templates and updating the CLI code to render the output.