### PR TITLE
Add Ritual Qt bindings

### DIFF
--- a/docs/compiled_ecosystem.json
+++ b/docs/compiled_ecosystem.json
@@ -44,7 +44,7 @@
   },
   "KAS": {
     "crates_io": "https://crates.io/crates/KAS",
-    "repo": "https://github.com/dhardy/kas",
+    "repo": "https://github.com/kas-gui/kas",
     "description": "The toolKit Abstraction System leverages generics and macros to compose widgets with encapsulated user data, provides a powerful event-handling model and scales to at least 100'000 widgets per window.",
     "docs": "https://docs.rs/kas",
     "tags": [
@@ -77,10 +77,20 @@
     "crates_io": "https://crates.io/crates/fltk",
     "repo": "https://github.com/MoAlyousef/fltk-rs",
     "description": "The FLTK crate is a crossplatform lightweight gui library which can be linked to statically to produce small, self-contained and fast binaries",
-    "docs": "https://docs.rs/crate/fltk",
+    "docs": "https://docs.rs/fltk",
     "tags": [
       "Bindings",
       "FLTK"
+    ]
+  },
+  "qt_widgets": {
+    "crates_io": "https://crates.io/crates/qt_widgets",
+    "repo": "https://github.com/rust-qt/ritual",
+    "description": "Ritual Qt bindings",
+    "docs": "https://rust-qt.github.io/qt/",
+    "tags": [
+      "Bindings",
+      "Qt"
     ]
   },
   "imgui-rs": {

--- a/docs/index.html
+++ b/docs/index.html
@@ -100,6 +100,10 @@
                 
             
                 
+                    <li data-crate-tag="FLTK">FLTK</li>
+                
+            
+                
                     <li data-crate-tag="GTK">GTK</li>
                 
             

--- a/ecosystem.json
+++ b/ecosystem.json
@@ -1,5 +1,14 @@
 [
   {
+    "name": "qt_widgets",
+    "description": "Ritual Qt bindings",
+    "docs": "https://rust-qt.github.io/qt/",
+    "tags": [
+      "Bindings",
+      "Qt"
+    ]
+  },
+  {
     "name": "fltk",
     "description": "The FLTK crate is a crossplatform lightweight gui library which can be linked to statically to produce small, self-contained and fast binaries",
     "tags": [


### PR DESCRIPTION
Hello. I'd like to add my Qt bindings. They are split into multiple crates, but this site seems to require a crate per library, so I've added `qt_widgets` as the most useful one.

The irrelevant changes to other crates are made by the cli.

https://github.com/areweguiyet/areweguiyet/pull/32 is also about this project too, so this PR should replace that. `qt_ritual_build` is a build script crate, so I would rather have `qt_widgets` listed as the crate name.
