### PR TITLE
add boringcactus blog post

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -76,6 +76,13 @@
     <div class="newsfeed-posts">
         
             <div>
+                <h3>A Survey of Rust GUI Libraries by boringcactus</h3>
+                
+    <a href="https:&#x2F;&#x2F;www.boringcactus.com&#x2F;2020&#x2F;08&#x2F;21&#x2F;survey-of-rust-gui-libraries.html">https:&#x2F;&#x2F;www.boringcactus.com&#x2F;2020&#x2F;08&#x2F;21&#x2F;survey-of-rust-gui-libraries.html</a>
+
+            </div>
+        
+            <div>
                 <h3>Entity-Component-System architecture for UI in Rust by Raph Levien</h3>
                 
     <a href="https:&#x2F;&#x2F;raphlinus.github.io&#x2F;personal&#x2F;2018&#x2F;05&#x2F;08&#x2F;ecs-ui.html">https:&#x2F;&#x2F;raphlinus.github.io&#x2F;personal&#x2F;2018&#x2F;05&#x2F;08&#x2F;ecs-ui.html</a>

--- a/docs/newsfeed/index.html
+++ b/docs/newsfeed/index.html
@@ -57,6 +57,13 @@
     <div class="newsfeed-posts">
         
             <div>
+                <h3>A Survey of Rust GUI Libraries by boringcactus</h3>
+                
+    <a href="https:&#x2F;&#x2F;www.boringcactus.com&#x2F;2020&#x2F;08&#x2F;21&#x2F;survey-of-rust-gui-libraries.html">https:&#x2F;&#x2F;www.boringcactus.com&#x2F;2020&#x2F;08&#x2F;21&#x2F;survey-of-rust-gui-libraries.html</a>
+
+            </div>
+        
+            <div>
                 <h3>Entity-Component-System architecture for UI in Rust by Raph Levien</h3>
                 
     <a href="https:&#x2F;&#x2F;raphlinus.github.io&#x2F;personal&#x2F;2018&#x2F;05&#x2F;08&#x2F;ecs-ui.html">https:&#x2F;&#x2F;raphlinus.github.io&#x2F;personal&#x2F;2018&#x2F;05&#x2F;08&#x2F;ecs-ui.html</a>

--- a/newsfeed.json
+++ b/newsfeed.json
@@ -1,5 +1,14 @@
 [
     {
+        "title": "A Survey of Rust GUI Libraries",
+        "author": "boringcactus",
+        "source": {
+            "kind": "Link",
+            "link": "https://www.boringcactus.com/2020/08/21/survey-of-rust-gui-libraries.html"
+        },
+        "order": 2
+    },
+    {
         "title": "#Rust2019 Are We GUI Yet?",
         "author": "Dustin Bensing",
         "source": {


### PR DESCRIPTION
i wrote a survey of the currently listed libraries, building a tiny todo list example with each. it's [here](https://www.boringcactus.com/2020/08/21/survey-of-rust-gui-libraries.html) and i think it'd fit nicely in the community blog posts.