### PR TITLE
removed deprecated/outdated crate

### DIFF
--- a/docs/compiled_ecosystem.json
+++ b/docs/compiled_ecosystem.json
@@ -43,6 +43,15 @@
       "GTK"
     ]
   },
+  "druid": {
+    "crates_io": "https://crates.io/crates/druid",
+    "repo": "https://github.com/xi-editor/druid",
+    "description": "Druid is a new Rust-native UI toolkit, still in early stages. Its main goal is performance, also aiming for small binary size and compile time, fast startup, and very easy build configuration (just cargo run). It is currently supporting Windows and macOS, with hope to support more in the future.",
+    "docs": null,
+    "tags": [
+      "piet"
+    ]
+  },
   "Azul": {
     "crates_io": "https://crates.io/crates/Azul",
     "repo": "https://github.com/maps4print/azul",
@@ -72,16 +81,6 @@
       "winit",
       "WebGPU",
       "proc-macro"
-    ]
-  },
-  "imgui": {
-    "crates_io": "https://crates.io/crates/imgui",
-    "repo": "https://github.com/Gekkio/imgui-rs",
-    "description": "High-level Rust bindings to dear imgui",
-    "docs": null,
-    "tags": [
-      "Bindings",
-      "Immediate mode API"
     ]
   },
   "conrod-core": {
@@ -132,13 +131,14 @@
       "WebRender"
     ]
   },
-  "druid": {
-    "crates_io": "https://crates.io/crates/druid",
-    "repo": "https://github.com/xi-editor/druid",
-    "description": "Druid is a new Rust-native UI toolkit, still in early stages. Its main goal is performance, also aiming for small binary size and compile time, fast startup, and very easy build configuration (just cargo run). It is currently supporting Windows and macOS, with hope to support more in the future.",
+  "imgui": {
+    "crates_io": "https://crates.io/crates/imgui",
+    "repo": "https://github.com/Gekkio/imgui-rs",
+    "description": "High-level Rust bindings to dear imgui",
     "docs": null,
     "tags": [
-      "piet"
+      "Bindings",
+      "Immediate mode API"
     ]
   },
   "core-foundation": {
@@ -170,13 +170,6 @@
       "Bindings",
       "GTK"
     ]
-  },
-  "neutrino": {
-    "crates_io": "https://crates.io/crates/neutrino",
-    "repo": "https://github.com/alexislozano/neutrino",
-    "description": "A GUI frontend in Rust based on web-view",
-    "docs": "https://docs.rs/neutrino",
-    "tags": []
   },
   "GTK": {
     "crates_io": "https://crates.io/crates/GTK",

--- a/ecosystem.json
+++ b/ecosystem.json
@@ -66,12 +66,6 @@
     ]
   },
   {
-    "name": "neutrino",
-    "repo": "https://github.com/alexislozano/neutrino",
-    "docs": "https://docs.rs/neutrino",
-    "tags": []
-  },
-  {
     "name": "Iced",
     "description": "A renderer-agnostic GUI library for Rust focused on simplicity and type-safety. Inspired by Elm.",
     "tags": []


### PR DESCRIPTION
I went and checked every repo of currently listed crates for those:

- which master branch hasn't been updated within past year
- marked as archived/deprecated

to my surprise, right now only alexislozano/neutrino is one such crate ("I am not working anymore on this project." in README.md, updated 4 months ago).

Should you accept this PR, I'll start working on automating this process.