### PR TITLE
Add post from Raph Levien and update Druid description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 cache.json
+docs/

--- a/ecosystem.json
+++ b/ecosystem.json
@@ -105,7 +105,7 @@
   },
   {
     "name": "druid",
-    "description": "Druid is a new Rust-native UI toolkit, still in early stages. Its main goal is performance, also aiming for small binary size and compile time, fast startup, and very easy build configuration (just cargo run). It is currently supporting Windows and macOS, with hope to support more in the future.",
+    "description": "Druid is an experimental Rust-native UI toolkit. Its main goal is to offer a polished user experience. There are many factors to this goal, including performance, a rich palette of interactions (hence a widget library to support them), and playing well with the native platform.",
     "tags": [
       "piet"
     ]

--- a/newsfeed.json
+++ b/newsfeed.json
@@ -1,5 +1,14 @@
 [
     {
+        "title": "Rust 2021: GUI",
+        "author": "Raph Levien",
+        "source": {
+            "kind": "Link",
+            "link": "https://raphlinus.github.io/rust/druid/2020/09/28/rust-2021.html"
+        },
+        "order": 2
+    },
+    {
         "title": "#Rust2019 Are We GUI Yet?",
         "author": "Dustin Bensing",
         "source": {

--- a/site/index.tera.html
+++ b/site/index.tera.html
@@ -27,28 +27,22 @@
 <section id="newsfeed" class="centered-content">
     <h2><a href="./newsfeed">Stay in the loop.</a></h2>
     <p>If you're working on or writing about GUIs in Rust, please contribute! Each
-        news entry can either be a post contributed to the Repo or a link back to
+        news entry can either be a post contributed to the repo or a link back to
         your blog, Reddit thread, etc. See
         <a href="https://github.com/areweguiyet/areweguiyet/blob/master/README.md">
         README</a> for details.</p>
-    <p>Here are the most recent posts on AreWeGuiYet:</p>
+    <p>Here are also some popular and recommended community links submitted to the site:</p>
     <div class="newsfeed-posts">
-        {% if news_posts | length > 0 %}
-            <div>
-                <h3 class="featured">{{news_posts.0.title}} by {{news_posts.0.author}}</h3>
-                {{macros::link(label=news_posts.0.link, href=news_posts.0.link)}}
-            </div>
-        {% endif %}
-        {% for post in news_posts | slice(start=1, end=3) %}
+        {% for post in news_links | slice(start=0, end=3) %}
             <div>
                 <h3>{{post.title}} by {{post.author}}</h3>
                 {{macros::link(label=post.link, href=post.link)}}
             </div>
         {% endfor %}
     </div>
-    <p>Here are also some popular and recommended community links submitted to the site:</p>
+    <p>Here are the most recent posts on AreWeGuiYet:</p>
     <div class="newsfeed-posts">
-        {% for post in news_links | slice(start=0, end=3) %}
+        {% for post in news_posts | slice(start=0, end=3) %}
             <div>
                 <h3>{{post.title}} by {{post.author}}</h3>
                 {{macros::link(label=post.link, href=post.link)}}


### PR DESCRIPTION
- Add GUI 2021 post, https://raphlinus.github.io/rust/druid/2020/09/28/rust-2021.html
- Display external links higher than posts hosted in the repo, because we haven't added one in awhile
- Update druid description based on Raph's feedback (it was a little out of date). Pulled new description from README.

Also includes:

- Ignore generated files, if people run the publish command locally to check their work.