### PR TITLE
Add some tags to SixtyFPS

### DIFF
--- a/ecosystem.json
+++ b/ecosystem.json
@@ -5,7 +5,13 @@
     "repo": "https://github.com/sixtyfpsui/sixtyfps",
     "description": "SixtyFPS is a toolkit to efficiently develop fluid graphical user interfaces for any display: embedded devices and desktop applications. It comes with a fast OpenGL renderer, a designer-friendly markup language and is written in Rust.",
     "docs": "https://docs.rs/sixtyfps/",
-    "tags": []
+    "tags": [
+        "proc-macro",
+        "winit",
+        "Embedded",
+        "CSS",
+        "MacOS"
+    ]
   },
   {
     "name": "native-windows-gui",


### PR DESCRIPTION
We target embedded, we support a Rust proc-macro for inline
markup, we run on winit, we support CSS-like property names, colors
and gradients and we also run on macOS.