### PR TITLE
Add cacao to ecosystem.json

### DIFF
--- a/ecosystem.json
+++ b/ecosystem.json
@@ -115,6 +115,15 @@
     ]
   },
   {
+    "name": "cacao",
+    "repo": "https://github.com/ryanmcgrath/cacao",
+    "description": "Rust bindings for AppKit (macOS, beta) and UIKit (iOS/tvOS, alpha).",
+    "docs": "https://docs.rs/cacao/0.2.0/cacao/",
+    "tags": [
+      "MacOS", "iOS"
+    ]
+  },
+  {
     "name": "sciter-rs",
     "tags": [
       "HTML",

--- a/ecosystem.json
+++ b/ecosystem.json
@@ -118,9 +118,10 @@
     "name": "cacao",
     "repo": "https://github.com/ryanmcgrath/cacao",
     "description": "Rust bindings for AppKit (macOS, beta) and UIKit (iOS/tvOS, alpha).",
-    "docs": "https://docs.rs/cacao/0.2.0/cacao/",
+    "docs": "https://docs.rs/cacao/",
     "tags": [
-      "MacOS", "iOS"
+      "MacOS",
+      "iOS"
     ]
   },
   {


### PR DESCRIPTION
Cacao wraps AppKit/UIKit to provide more familiar bindings than what's found in core-foundation. While I'd still consider it beta-ish, it's very usable now and published on crates.io. Would love to get more exposure/eyes on it.

Thanks!