### PR TITLE
feature: add crates.io download badge to the crate card

### DIFF
--- a/docs/main.css
+++ b/docs/main.css
@@ -299,3 +299,8 @@ p {
         flex: 0 0 378px;
     }
 }
+
+.badge {
+    margin: 1px;
+    align-self: flex-end;
+}

--- a/docs/main.js
+++ b/docs/main.js
@@ -21,6 +21,9 @@ Vue.component('crate-card', {
             <div class="content">
                 <p>{{ crate.description }}</p>
             </div>
+            <div class="badge">
+                <img alt="Crates.io" v-bind:src="'https://img.shields.io/crates/d/' + crate.name + '?color=9f703d'">
+            </div>
             <ul v-if="crate.tags" class="ecosystem-tags">
                 <li v-for="tag in crate.tags">{{ tag }}</li>
             </ul>


### PR DESCRIPTION
There's discussion in #58 (including screenshots) about which metric to include. I think downloads is a better metric, but depending on what you want to show, we can change it (or add multiple badges)!

Here's a preview site of my feature branch in case any maintainers or designers want to tweak some things (feedback is very welcome): https://dazzling-wing-7fff66.netlify.app/

One thing to consider prior to merging is that this feature currently depends on shields.io to render the svg. An alternative would be using one of these [methods to get the data from crates.io](https://crates.io/data-access).