### PR TITLE
Add Relm4

### DIFF
--- a/ecosystem.json
+++ b/ecosystem.json
@@ -1,16 +1,25 @@
 [
   {
+    "name": "Relm4",
+    "tags": [
+      "GTK",
+      "Bindings",
+      "MacOS",
+      "CSS"
+    ]
+  },
+  {
     "name": "SixtyFPS",
     "skip_crates_io": true,
     "repo": "https://github.com/sixtyfpsui/sixtyfps",
     "description": "SixtyFPS is a toolkit to efficiently develop fluid graphical user interfaces for any display: embedded devices and desktop applications. It comes with a fast OpenGL renderer, a designer-friendly markup language and is written in Rust.",
     "docs": "https://docs.rs/sixtyfps/",
     "tags": [
-        "proc-macro",
-        "winit",
-        "Embedded",
-        "CSS",
-        "MacOS"
+      "proc-macro",
+      "winit",
+      "Embedded",
+      "CSS",
+      "MacOS"
     ]
   },
   {
@@ -37,7 +46,6 @@
   },
   {
     "name": "egui",
-    "crates_io": "https://crates.io/crates/egui",
     "description": "Highly portable immediate mode GUI library in pure Rust",
     "docs": "https://docs.rs/egui",
     "tags": [


### PR DESCRIPTION
I hope it's intentional that the CLI didn't include the links to crates.io etc. because it automatically found the crate there.