### PR TITLE
fix: use legacy channel for vue cdn

### DIFF
--- a/site/index.tera.html
+++ b/site/index.tera.html
@@ -1,7 +1,7 @@
 {% extends "base.tera.html" %}
 {% import "macros.tera.html" as macros %}
 {% block head %}
-<script src="https://cdn.jsdelivr.net/npm/vue"></script>
+<script src="https://cdn.jsdelivr.net/npm/vue@legacy"></script>
 {% endblock head%}
 {% block content %}
 <section class="centered-content">


### PR DESCRIPTION
Closes #88