### PR TITLE
slint: include link to crates.io

### DIFF
--- a/ecosystem.toml
+++ b/ecosystem.toml
@@ -98,9 +98,7 @@ tags = [
 ]
 
 [crate.slint]
-skip-crates-io = true
 name = "Slint"
-repo = "https://github.com/slint-ui/slint"
 description = "Slint is a toolkit to efficiently develop fluid graphical user interfaces for any display: embedded devices and desktop applications. It comes with a fast OpenGL renderer, a designer-friendly markup language and is written in Rust."
 docs = "https://docs.rs/slint/"
 tags = [

--- a/ecosystem.toml
+++ b/ecosystem.toml
@@ -99,7 +99,7 @@ tags = [
 
 [crate.slint]
 name = "Slint"
-description = "Slint is a toolkit to efficiently develop fluid graphical user interfaces for any display: embedded devices and desktop applications. It comes with a fast OpenGL renderer, a designer-friendly markup language and is written in Rust."
+description = "Slint is a toolkit to efficiently develop fluid graphical user interfaces for any display: embedded devices and desktop applications. It comes with a fast OpenGL renderer, a designer-friendly markup language and is written in Rust. Triple-licensed: GPLv3, Royalty-free, and Commercial."
 docs = "https://docs.rs/slint/"
 tags = [
   "proc-macro",


### PR DESCRIPTION
The repo tag is automatically picked up from crates.io