### PR TITLE
Add Rust-In-Flutter

### DIFF
--- a/ecosystem.toml
+++ b/ecosystem.toml
@@ -276,3 +276,12 @@ tags = [
   "bindings",
   "gtk",
 ]
+
+[crate.rifs]
+name = "Rust-In-Flutter"
+tags = [
+  "bindings",
+  "flutter",
+  "native",
+  "cross-platform",
+]


### PR DESCRIPTION
This PR adds [Rust-In-Flutter](https://github.com/cunarist/rust-in-flutter) to the crate list