### PR TITLE
Change Rust-In-Flutter to Rinf

### DIFF
--- a/ecosystem.toml
+++ b/ecosystem.toml
@@ -276,7 +276,6 @@ tags = [
 
 [crate.rinf]
 name = "Rinf"
-docs = "https://rinf-docs.cunarist.com"
 tags = [
   "bindings",
   "flutter",

--- a/ecosystem.toml
+++ b/ecosystem.toml
@@ -276,7 +276,6 @@ tags = [
 
 [crate.rinf]
 name = "Rinf"
-description = "Rust as your Flutter backend, Flutter as your Rust frontend"
 docs = "https://rinf-docs.cunarist.com"
 tags = [
   "bindings",

--- a/ecosystem.toml
+++ b/ecosystem.toml
@@ -274,12 +274,13 @@ tags = [
   "gtk",
 ]
 
-[crate.rifs]
-name = "Rust-In-Flutter"
+[crate.rinf]
+name = "Rinf"
+description = "Rust as your Flutter backend, Flutter as your Rust frontend"
+docs = "https://rinf-docs.cunarist.com"
 tags = [
   "bindings",
   "flutter",
-  "native",
   "cross-platform",
 ]
 


### PR DESCRIPTION
The name has changed because the original was too long. This is a simple update, and it removes 'native' tag that might not be appropriate.