### PR TITLE
Change the reddit link in the 2019 blog post to fix link checking

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -5,3 +5,7 @@ title = "Are we GUI yet?"
 description = "The state of building user interfaces in Rust"
 # compile_sass = true
 # highlight_code = true
+
+[link_checker]
+# Reddit sometimes 403s us in GitHub Actions
+skip_prefixes = ["https://www.reddit.com/r/rust/"]


### PR DESCRIPTION
We could also remove Zola's CHECK_LINKS, but I think that one is still generally useful for detecting when to pull out the wayback machine.