### PR TITLE
chore: Update actions to latest available versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           cargo run -- fetch
 
       - name: Build site
-        uses: shalzz/zola-deploy-action@v0.17.2
+        uses: shalzz/zola-deploy-action@v0.18.0
         env:
           BUILD_ONLY: true
           BUILD_FLAGS: --drafts
@@ -66,7 +66,7 @@ jobs:
           cargo run -- fetch
 
       - name: Deploy site
-        uses: shalzz/zola-deploy-action@v0.17.2
+        uses: shalzz/zola-deploy-action@v0.18.0
         env:
           PAGES_BRANCH: gh-pages
           CHECK_LINKS: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: cargo fmt
         run: cargo fmt --check
@@ -32,7 +32,7 @@ jobs:
     if: github.ref != 'refs/heads/master'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Build CLI
         run: cargo build --verbose
@@ -55,7 +55,7 @@ jobs:
     if: github.ref == 'refs/heads/master'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Build CLI
         run: cargo build --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CLI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
   schedule:
     - cron: "0 0 * * 1"
   workflow_dispatch:
@@ -18,13 +18,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: cargo fmt
-      run: cargo fmt --check
+      - name: cargo fmt
+        run: cargo fmt --check
 
-    - name: cargo clippy
-      run: cargo clippy
+      - name: cargo clippy
+        run: cargo clippy
 
   build:
     name: Builds project, fetching latest metadata and verifying configuration
@@ -32,22 +32,22 @@ jobs:
     if: github.ref != 'refs/heads/master'
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Build CLI
-      run: cargo build --verbose
+      - name: Build CLI
+        run: cargo build --verbose
 
-    - name: Update data
-      run: |
-        cargo run -- clean
-        cargo run -- fetch
+      - name: Update data
+        run: |
+          cargo run -- clean
+          cargo run -- fetch
 
-    - name: Build site
-      uses: shalzz/zola-deploy-action@v0.17.2
-      env:
-        BUILD_ONLY: true
-        BUILD_FLAGS: --drafts
-        CHECK_LINKS: true
+      - name: Build site
+        uses: shalzz/zola-deploy-action@v0.17.2
+        env:
+          BUILD_ONLY: true
+          BUILD_FLAGS: --drafts
+          CHECK_LINKS: true
 
   deploy:
     name: Deploys to GH Pages
@@ -55,19 +55,19 @@ jobs:
     if: github.ref == 'refs/heads/master'
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Build CLI
-      run: cargo build --verbose
+      - name: Build CLI
+        run: cargo build --verbose
 
-    - name: Update data
-      run: |
-        cargo run -- clean
-        cargo run -- fetch
+      - name: Update data
+        run: |
+          cargo run -- clean
+          cargo run -- fetch
 
-    - name: Deploy site
-      uses: shalzz/zola-deploy-action@v0.17.2
-      env:
-        PAGES_BRANCH: gh-pages
-        CHECK_LINKS: true
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Deploy site
+        uses: shalzz/zola-deploy-action@v0.17.2
+        env:
+          PAGES_BRANCH: gh-pages
+          CHECK_LINKS: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What?
The current GitHub Actions [workflow ](https://github.com/areweguiyet/areweguiyet/blob/master/.github/workflows/ci.yml) in this repository is still using actions/checkout@v2, which is still running on Node v12 runtime. Due to this we are seeing [deprecation warning](https://github.com/areweguiyet/areweguiyet/actions/runs/7332224838) in every action run.

[GitHub Actions: All Actions will run on Node16 instead of Node12 by default](https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/)





### Solutions
Update actions/checkout@v2 to the latest version, which uses Node v16 as their runtime. This update is necessary to avoid actions failure in the future when GitHub Actions begins enforcing the use of Node16, replacing Node12.