### PR TITLE
Renaming Gooey to Cushy

### DIFF
--- a/ecosystem.toml
+++ b/ecosystem.toml
@@ -298,8 +298,8 @@ tags = ["bindings","tk"]
 name = "rstk"
 tags = ["tk"]
 
-[crate.gooey]
-name = "Gooey"
+[crate.cushy]
+name = "Cushy"
 tags = ["winit"]
 
 [crate.floem]


### PR DESCRIPTION
I renamed this crate when releasing [v0.2](https://github.com/khonsulabs/cushy/releases/tag/v0.2.0).

~~I also took a stab at adding a description for the crate~~.

I didn't originally submit the crate here since it was so new, and I didn't notice until today that someone else had listed it (thank you!). The entry in the news feed is still fine -- I left the text of the original post the same but updated all the links.

Thank you for maintaining this resource!