### PR TITLE
Update Floem listing

### DIFF
--- a/content/ecosystem/reactive.md
+++ b/content/ecosystem/reactive.md
@@ -1,0 +1,3 @@
++++
+title = "Reactive API"
++++

--- a/ecosystem.toml
+++ b/ecosystem.toml
@@ -312,4 +312,4 @@ tags = ["winit"]
 [crate.floem]
 name = "Floem"
 description = "UI library aiming to be extremely performant while providing world-class developer ergonomics. From the team that made the Lapce code editor."
-docs = "https://github.com/lapce/floem"
+tags = ["reactive", "winit"]


### PR DESCRIPTION
- Floem is published now, so most metadata can be retrieved from crates.io
- Add tags to denote that it's built on reactivity principles and winit