### PR TITLE
Added `ribir` & unified punctiuation of descriptions

### DIFF
--- a/ecosystem.toml
+++ b/ecosystem.toml
@@ -23,7 +23,7 @@
 
 [crate.gpui]
 name = "GPUI"
-description = "A hybrid immediate and retained mode, GPU accelerated, UI framework, designed to support a wide variety of applications"
+description = "A hybrid immediate and retained mode, GPU accelerated, UI framework, designed to support a wide variety of applications."
 repo = "https://github.com/zed-industries/zed"
 tags = [
   "macos",
@@ -31,7 +31,7 @@ tags = [
 
 [crate.vizia]
 name = "Vizia"
-description = "A declarative desktop GUI framework"
+description = "A declarative desktop GUI framework."
 tags = [
   "winit",
 ]
@@ -178,7 +178,7 @@ tags = [
 ]
 
 [crate.qt_widgets]
-description = "Ritual Qt bindings"
+description = "Ritual Qt bindings."
 docs = "https://rust-qt.github.io/qt/"
 tags = [
   "bindings",
@@ -186,7 +186,7 @@ tags = [
 ]
 
 [crate.fltk]
-description = "The FLTK crate is a crossplatform lightweight gui library which can be linked to statically to produce small, self-contained and fast binaries"
+description = "The FLTK crate is a crossplatform lightweight gui library which can be linked to statically to produce small, self-contained and fast binaries."
 tags = [
   "bindings",
   "fltk",
@@ -247,7 +247,7 @@ tags = []
 [crate.xilem]
 skip-crates-io = true
 name = "Xilem"
-description = "An experimental Rust architecture for reactive UI"
+description = "An experimental Rust architecture for reactive UI."
 repo = "https://github.com/linebender/xilem/"
 
 [crate.rust-qt-binding-generator]
@@ -299,7 +299,7 @@ tags = [
 
 [crate.pax-std]
 name = "Pax"
-description = "User interface language and 2D layout engine for cross-platform apps"
+description = "User interface language and 2D layout engine for cross-platform apps."
 tags = []
 
 [crate.tinyfiledialogs]
@@ -321,3 +321,6 @@ tags = ["winit"]
 name = "Floem"
 description = "UI library aiming to be extremely performant while providing world-class developer ergonomics. From the team that made the Lapce code editor."
 tags = ["reactive", "winit"]
+
+[crate.ribir]
+name = "Ribir"


### PR DESCRIPTION
* Added [`Ribir`](https://crates.io/crates/ribir) ([repo](https://github.com/RibirX/Ribir)).
   I didn't add `tags` since there are no written guiderails in the `CONTRIBUTING.md` for what that field should contain. The `tags` used in `ecosystem.toml` on other crates seem to follow no stringent logic. Some pertain to _what_, some to _how_, etc.

* Unified use of punctuation in `description` fields. Some had a terminating period, some didn't.
 
P.S.: It would help if `CONTRIBUTING.md` listed all the fields one should populate, when a crate is not published on `crates.io`. Maybe an example `toml` snippet? :grin:

