### PR TITLE
Normalize trailing punctuation in crate descriptions

### DIFF
--- a/templates/index.tera.html
+++ b/templates/index.tera.html
@@ -116,9 +116,9 @@
             <div class="content">
                 <p>
                     {% if crate.description %}
-                        {{ crate.description }}
+                        {{ crate.description | trim | trim_end_matches(pat=".") }}.
                     {% else %}
-                        {{ crates_io.description }}
+                        {{ crates_io.description | trim | trim_end_matches(pat=".") }}.
                     {% endif %}
                 </p>
             </div>


### PR DESCRIPTION
As suggested in https://github.com/areweguiyet/areweguiyet/pull/152, we now normalize the crate description to always add a `.`.