### PR TITLE
Do not skip crates.io for Xilem

### DIFF
--- a/ecosystem.toml
+++ b/ecosystem.toml
@@ -245,7 +245,6 @@ tags = [
 tags = []
 
 [crate.xilem]
-skip-crates-io = true
 name = "Xilem"
 description = "An experimental Rust architecture for reactive UI"
 repo = "https://github.com/linebender/xilem/"


### PR DESCRIPTION
Xilem was published to crates.io with its 0.1 release, so `skip-crates-io` can be removed.

crates.io page: https://crates.io/crates/xilem
