### PR TITLE
Update GPUI

### DIFF
--- a/ecosystem.toml
+++ b/ecosystem.toml
@@ -24,9 +24,12 @@
 [crate.gpui]
 name = "GPUI"
 description = "A hybrid immediate and retained mode, GPU accelerated, UI framework, designed to support a wide variety of applications"
+docs = "https://www.gpui.rs/"
 repo = "https://github.com/zed-industries/zed"
 tags = [
+  "winapi",
   "macos",
+  "linux",
 ]
 
 [crate.vizia]


### PR DESCRIPTION
GPUI has support for Windows and Linux, the docs has also been changed to their official website, as GPUI has not actually been published to the crate yet.