### PR TITLE
Add tag descriptions

### DIFF
--- a/content/ecosystem/css.md
+++ b/content/ecosystem/css.md
@@ -1,3 +1,4 @@
 +++
 title = "CSS"
+description = "Allows styling via CSS"
 +++

--- a/content/ecosystem/embedded.md
+++ b/content/ecosystem/embedded.md
@@ -1,3 +1,4 @@
 +++
 title = "Embedded"
+description = "Runs on embedded systems"
 +++

--- a/content/ecosystem/fltk.md
+++ b/content/ecosystem/fltk.md
@@ -1,3 +1,4 @@
 +++
 title = "FLTK"
+description = "Uses FLTK as a GUI library (cross-platform)"
 +++

--- a/content/ecosystem/gtk.md
+++ b/content/ecosystem/gtk.md
@@ -1,3 +1,4 @@
 +++
 title = "GTK"
+description = "Uses GTK as a GUI library (cross-platform)"
 +++

--- a/content/ecosystem/html.md
+++ b/content/ecosystem/html.md
@@ -1,3 +1,4 @@
 +++
 title = "HTML"
+description = "Renders HTML pages"
 +++

--- a/content/ecosystem/immediate.md
+++ b/content/ecosystem/immediate.md
@@ -1,3 +1,4 @@
 +++
 title = "Immediate mode API"
+description = "Scene management is left to the user"
 +++

--- a/content/ecosystem/ios.md
+++ b/content/ecosystem/ios.md
@@ -1,3 +1,4 @@
 +++
 title = "iOS"
+description = "Runs on iOS"
 +++

--- a/content/ecosystem/macos.md
+++ b/content/ecosystem/macos.md
@@ -1,3 +1,4 @@
 +++
 title = "MacOS"
+description = "Runs on MacOS"
 +++

--- a/content/ecosystem/proc-macro.md
+++ b/content/ecosystem/proc-macro.md
@@ -1,3 +1,4 @@
 +++
 title = "proc-macro"
+description = "Exposes procedural macros"
 +++

--- a/content/ecosystem/qml.md
+++ b/content/ecosystem/qml.md
@@ -1,3 +1,4 @@
 +++
 title = "QML"
+description = "Supports Qt Modeling Language"
 +++

--- a/content/ecosystem/qt.md
+++ b/content/ecosystem/qt.md
@@ -1,3 +1,4 @@
 +++
 title = "Qt"
+description = "Uses Qt as a GUI library (cross-platform)"
 +++

--- a/content/ecosystem/reactive.md
+++ b/content/ecosystem/reactive.md
@@ -1,3 +1,4 @@
 +++
 title = "Reactive API"
+description = "Propages widget events to their children"
 +++

--- a/content/ecosystem/webgpu.md
+++ b/content/ecosystem/webgpu.md
@@ -1,3 +1,4 @@
 +++
 title = "WebGPU"
+description = "Runs on the browser via WebGPU (experimental)"
 +++

--- a/content/ecosystem/webrender.md
+++ b/content/ecosystem/webrender.md
@@ -1,3 +1,4 @@
 +++
 title = "WebRender"
+description = "Runs on Firefox via WebRender (experimental)"
 +++

--- a/content/ecosystem/winapi.md
+++ b/content/ecosystem/winapi.md
@@ -1,3 +1,4 @@
 +++
 title = "WinApi"
+description = "Uses the native Windows API"
 +++

--- a/content/ecosystem/winit.md
+++ b/content/ecosystem/winit.md
@@ -1,3 +1,4 @@
 +++
 title = "winit"
+description = "Uses winit as a window management library (cross-platform)"
 +++


### PR DESCRIPTION
Hi,

This PR adds [`title` attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title) to the tags so as to present a tooltip describing the tag to the user:
https://github.com/areweguiyet/areweguiyet/blob/2f1eb5c481a1542f5cfe04cbd0f5d204cd331710/templates/index.tera.html#L54-L56

Untouched tags are:
- https://github.com/areweguiyet/areweguiyet/blob/2f1eb5c481a1542f5cfe04cbd0f5d204cd331710/content/ecosystem/piet.md#L1-L3
No crate has this tag, but there is a [`piet` crate](https://crates.io/crates/piet).