### PR TITLE
Remove old crates

### DIFF
--- a/ecosystem.toml
+++ b/ecosystem.toml
@@ -135,22 +135,10 @@ tags = [
   "macos",
 ]
 
-[crate.native-windows-gui]
-tags = [
-  "bindings",
-  "proc-macro",
-  "winapi",
-]
-
 [crate.windows]
 tags = [
   "bindings",
   "winapi",
-]
-
-[crate.iui]
-tags = [
-  "bindings",
 ]
 
 [crate.lvgl]
@@ -178,19 +166,6 @@ tags = [
   "html",
   "macos",
   "gtk",
-]
-
-[crate.vgtk]
-tags = [
-  "gtk",
-]
-
-[crate.qt_widgets]
-description = "Ritual Qt bindings"
-docs = "https://rust-qt.github.io/qt/"
-tags = [
-  "bindings",
-  "qt",
 ]
 
 [crate.fltk]
@@ -228,12 +203,6 @@ tags = [
 tags = [
   "macos",
   "ios",
-]
-
-[crate.sciter-rs]
-tags = [
-  "html",
-  "css",
 ]
 
 [crate.azul]


### PR DESCRIPTION
Remove:
- `vgtk` (CC @philip-peterson who requested it in https://github.com/areweguiyet/areweguiyet/issues/42)
- `native-windows-gui` (CC @gabdube who added it in https://github.com/areweguiyet/areweguiyet/pull/46)
- `iui` (CC @londospark who added it in https://github.com/areweguiyet/areweguiyet/pull/35)
- ~`GemGui` (CC @mmertama who added it in https://github.com/areweguiyet/areweguiyet/pull/109)~
- `qt_widgets` (CC @Riateche who added it in https://github.com/areweguiyet/areweguiyet/pull/36)
- `sciter-rs` (CC @EdorianDark/@serak who requested it in https://github.com/areweguiyet/areweguiyet/issues/11)

As their repositories have not been updated in ~2 years.

Feel free to state if any of these are still active, then I'll re-add them.