### PR TITLE
Add Auralis reactive kernel

### DIFF
--- a/ecosystem.toml
+++ b/ecosystem.toml
@@ -21,6 +21,11 @@
 # # Defaults to what is specified on crates.io, or otherwise to docs.rs.
 # docs = "https://domain.invalid/mycrate/docs"
 
+[crate.auralis-signal]
+name = "Auralis"
+description = "An async-first reactive kernel for Rust: Signal + Memo + TaskScope. Zero dependencies, single-threaded by design, #![forbid(unsafe_code)]."
+tags = ["reactive", "wasm", "async"]
+
 [crate.blinc_app]
 name = "blinc"
 docs = "https://project-blinc.github.io/Blinc"


### PR DESCRIPTION
Auralis is an async-first reactive kernel for Rust. Zero dependencies, #![forbid(unsafe_code)], single-threaded by design. Adds reactive state management primitives (Signal + Memo + TaskScope) that can be used independently or as the foundation for UI frameworks.