### PR TITLE
Add llimphi

### DIFF
--- a/ecosystem.toml
+++ b/ecosystem.toml
@@ -364,3 +364,18 @@ tags = [
   "css",       
   "macos", 
 ]
+
+[crate.llimphi]
+name = "llimphi"
+tags = [
+  "native",
+  "declarative",
+  "reactive",
+  "winit",
+  "linux",
+  "windows",
+  "macos",
+  "android",
+  "wasm",
+  "accessibility",
+]


### PR DESCRIPTION
Adds **llimphi**, a native retained-mode Rust UI framework (Elm-style View<Msg> loop on vello + wgpu + taffy + parley) that also ships a 3D voxel engine mounting into the 2D layout tree. MIT-licensed, just published to crates.io: https://crates.io/crates/llimphi · source: https://github.com/tawasuyu/llimphi