### PR TITLE
Add fenestra

### DIFF
--- a/ecosystem.toml
+++ b/ecosystem.toml
@@ -364,3 +364,12 @@ tags = [
   "css",       
   "macos", 
 ]
+
+[crate.fenestra]
+name = "fenestra"
+tags = [
+  "native",
+  "winit",
+  "webgpu",
+  "accessibility",
+]


### PR DESCRIPTION
fenestra is a pure-Rust native GUI framework built on winit, wgpu, vello, parley, and taffy: web-grade visuals (soft shadows, OKLCH color, a themed widget kit) with first-class headless rendering, so a UI can be rendered, queried, and asserted against without a display attached.

Only `name` and `tags` are set so the rest populates from crates.io per the contributing guide. Ran `cargo run -- fetch` locally before opening this.

https://github.com/richer-richard/fenestra