### PR TITLE
Add guise (gpui component library)

### DIFF
--- a/ecosystem.toml
+++ b/ecosystem.toml
@@ -364,3 +364,11 @@ tags = [
   "css",       
   "macos", 
 ]
+
+[crate.guise-ui]
+name = "guise"
+tags = [
+  "gpui",
+  "macos",
+  "linux",
+]


### PR DESCRIPTION
Adds the [guise-ui](https://crates.io/crates/guise-ui) crate (project name guise) — a Mantine-inspired component library for gpui, the GPU-accelerated Rust UI framework that powers Zed. Entry follows the crates.io-crate convention: name and tags only, so description/repo/docs are pulled from crates.io.
