### PR TITLE
Add Fission to ecosystem

### DIFF
--- a/ecosystem.toml
+++ b/ecosystem.toml
@@ -38,6 +38,22 @@ tags = [
   "reactive",
 ]
 
+[crate.fission]
+name = "Fission"
+tags = [
+  "cross-platform",
+  "native",
+  "accessibility",
+  "winit",
+  "macos",
+  "ios",
+  "android",
+  "linux",
+  "windows",
+  "wasm",
+  "webgpu",
+]
+
 [crate.ribir]
 name = "Ribir"
 description = "Ribir is a Rust GUI framework that helps you build beautiful and native multi-platform applications from a single codebase."


### PR DESCRIPTION
 ## Summary

  Adds Fission to the Are We GUI Yet ecosystem list.

  Fission is a Rust-native cross-platform UI framework with support across desktop, mobile, web, terminal, static site, and server-rendered targets. This entry keeps the local metadata minimal and lets crates.io
  provide the crate description, repository, and documentation links, matching the contribution guidance for crates already published on crates.io...I think