### PR TITLE
Add FUI-RS

### DIFF
--- a/ecosystem.toml
+++ b/ecosystem.toml
@@ -38,6 +38,19 @@ tags = [
   "reactive",
 ]
 
+[crate.fui-rs]
+name = "FUI-RS"
+tags = [
+  "cross-platform",
+  "native",
+  "wasm",
+  "macos",
+  "linux",
+  "winapi",
+  "accessibility",
+  "proc-macro",
+]
+
 [crate.ribir]
 name = "Ribir"
 description = "Ribir is a Rust GUI framework that helps you build beautiful and native multi-platform applications from a single codebase."


### PR DESCRIPTION
Adds FUI-RS, a retained-mode Rust UI SDK targeting browser/WebAssembly and native macOS, Windows, and Linux applications without a WebView thus bypassing DOM/CSS/Javascript.