### PR TITLE
Add Qt Bridge for Rust

### DIFF
--- a/content/newsfeed/links.toml
+++ b/content/newsfeed/links.toml
@@ -19,6 +19,12 @@
 # All keys are required. Please keep this file in order with newest first.
 
 [[links]]
+title = "A Cross-Platform Rust UI Framework via Qt’s Bridging Technology"
+author = "Matthias Rauter"
+link = "https://www.qt.io/blog/rust-ui-framework-via-bridging-technology"
+date = 2026-07-01
+
+[[links]]
 title = "Building apps in Rust shouldn't be this hard, so I made Ply"
 author = "TheRedDeveloper"
 link = "https://plyx.iz.rs/blog/introducing-ply/"

--- a/ecosystem.toml
+++ b/ecosystem.toml
@@ -21,6 +21,14 @@
 # # Defaults to what is specified on crates.io, or otherwise to docs.rs.
 # docs = "https://domain.invalid/mycrate/docs"
 
+[crate.qtbridge]
+name = "Qt Bridge"
+tags = [
+  "bindings",
+  "qt",
+  "qml",
+]
+
 [crate.blinc_app]
 name = "blinc"
 docs = "https://project-blinc.github.io/Blinc"
@@ -352,15 +360,15 @@ tags = ["emscripten", "wasm", "android", "ios"]
 name = "Pane UI"
 description = "A user friendly data defined imediate mode Ui system. Define your menus in ron."
 tags = [
-  "winit",      
-  "wgpu",       
-  "immediate", 
+  "winit",
+  "wgpu",
+  "immediate",
 ]
 
 [crate.rosin]
 name = "Rosin"
 tags = [
-  "immediate",      
-  "css",       
-  "macos", 
+  "immediate",
+  "css",
+  "macos",
 ]


### PR DESCRIPTION
This library enables building modern Qt Quick user interfaces with a Rust backend, without writing any C++ code. It allows you to run [QML](https://doc.qt.io/qt-6/qmlreference.html) code and expose Rust types to QML using simple attribute macros.