### PR TITLE
Add 2026 Rust GUI survey to newsfeed

### DIFF
--- a/content/newsfeed/links.toml
+++ b/content/newsfeed/links.toml
@@ -20,7 +20,7 @@
 
 [[links]]
 title = "A 2026 Survey of Rust GUI Libraries"
-author = "Jiayi Zhuang"
+author = "Wybxc"
 link = "https://blog.wybxc.cc/blog/rust-gui-survey-2026/"
 date = 2026-08-22
 

--- a/content/newsfeed/links.toml
+++ b/content/newsfeed/links.toml
@@ -19,6 +19,12 @@
 # All keys are required. Please keep this file in order with newest first.
 
 [[links]]
+title = "A 2026 Survey of Rust GUI Libraries"
+author = "Jiayi Zhuang"
+link = "https://blog.wybxc.cc/blog/rust-gui-survey-2026/"
+date = 2026-08-22
+
+[[links]]
 title = "Building apps in Rust shouldn't be this hard, so I made Ply"
 author = "TheRedDeveloper"
 link = "https://plyx.iz.rs/blog/introducing-ply/"


### PR DESCRIPTION
This PR add the blog post "A 2026 Survey of Rust GUI Libraries" to the newsfeed.