### PR TITLE
Add Cranpose

### DIFF
--- a/ecosystem.toml
+++ b/ecosystem.toml
@@ -364,3 +364,19 @@ tags = [
   "css",       
   "macos", 
 ]
+
+[crate.cranpose]
+name = "Cranpose"
+description = "Cranpose is a declarative UI framework for Rust modelled on Jetpack Compose. It is pre-alpha: the API changes without a deprecation cycle between releases."
+tags = [
+  "declarative",
+  "proc-macro",
+  "cross-platform",
+  "winit",
+  "wasm",
+  "android",
+  "ios",
+  "macos",
+  "linux",
+  "winapi",
+]


### PR DESCRIPTION
Adds Cranpose, a declarative UI framework for Rust modelled on Jetpack Compose, published on crates.io as `cranpose` (currently v0.1.104, Apache-2.0).

Per CONTRIBUTING, `repo` and `docs` are left unset so they are populated from the crate's own crates.io metadata.