### PR TITLE
Add libui

### DIFF
--- a/ecosystem.toml
+++ b/ecosystem.toml
@@ -364,3 +364,14 @@ tags = [
   "css",       
   "macos", 
 ]
+
+[crate.libui]
+tags = [
+  "native",
+  "cross-platform",
+  "winapi",
+  "macos",
+  "linux",
+  "bindings",
+  "proc-macro",
+]


### PR DESCRIPTION
Adds libui, a native cross-platform UI toolkit. libui utilizes the platforms GUI APIs rather than shipping a renderer.